### PR TITLE
don't try to use db connection if error is thrown

### DIFF
--- a/index.js
+++ b/index.js
@@ -244,12 +244,12 @@ function runMongoMigrate(direction, migrationEnd) {
 	function performMigration(direction, migrateTo) {
 		var db = require('./lib/db');
 		db.getConnection(dbConfig || require(cwd + path.sep + configFileName)[dbProperty], function (err, db) {
-			var migrationCollection = db.migrationCollection,
-					dbConnection = db.connection;
 			if (err) {
 				console.error('Error connecting to database');
 				process.exit(1);
 			}
+			var migrationCollection = db.migrationCollection,
+					dbConnection = db.connection;
 
 			migrationCollection.find({}).sort({num: -1}).limit(1).toArray(function (err, migrationsRun) {
 				if (err) {


### PR DESCRIPTION
if there are issues connecting to mongo, db.migrationCollection is still called. When db.getConnection fails to get  a connection, db is undefined and this exception is raised:

~/mongo-migrate/index.js:247
var migrationCollection = db.migrationCollection,
                                        ^
TypeError: Cannot read property 'migrationCollection' of undefined

Moving error conditional up, so that an error is logged instead.
