### PR TITLE
Added support for replica sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Built with a starting framework from: https://github.com/visionmedia/node-migrat
 
 ## Installation
 	$ npm install mongo-migrate
-	
+
 ##Usage
 ```
 Usage: node mongo-migrate [options] [command]
@@ -15,16 +15,16 @@ Options:
 	-runmm, --runMongoMIgrate		Run the migration from the command line
 	-c, --chdir <path>				Change the working directory (if you wish to store your migrations outside of this folder
 	-cfg, --config <filename>		DB config file name
-	--dbn, --dbPropName <string>		Property name for the database connection in the config file. The configuration file should 
-									contain something like 
-									{ 	
+	--dbn, --dbPropName <string>		Property name for the database connection in the config file. The configuration file should
+									contain something like
+									{
 										appDb : { //appDb would be the dbPropName
-											host: 'localhost', 
+											host: 'localhost',
 											db: 'mydbname',
 											//port: '27017' //include a port if necessary
 										}
 									}
-	
+
 Commands:
 	down [revision]		migrate down (stop at optional revision name/number)
 	up [revision]		migrate up (stop at optional revision name/number)
@@ -74,7 +74,7 @@ The second creates `./migrations/0010-add-owners.js`, which we can populate:
 ```
 	exports.up = function(db, next){
 		var owners = mongodb.Collection(db, 'owners');
-		owners.insert({name: 'taylor'}, next);		
+		owners.insert({name: 'taylor'}, next);
     };
 
 	exports.down = function(db, next){
@@ -144,7 +144,15 @@ This would tell mongo-migrate your config file looks something like:
 		}
 	}
 ```
-
+To connect to a replica set, use  the `replicaSet` property:
+```
+	{
+		dbSettings: {
+			replicaSet : ["localhost:27017","localhost:27018","localhost:27019"],
+			db: 'myDatabaseName',
+		}
+	}
+```
 
 All of these settings can be combined as desired, except for the up/down obviously ;)
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -12,13 +12,29 @@ function getDbOpts(opts) {
 	return opts;
 }
 
+function getReplicaSetServers(opts, mongodb){
+    var replServers = opts.replicaSet.map(function(replicaSet){
+      var split = replicaSet.split(":");
+      var host  = split[0] || 'localhost';
+      var port = split[1] || 27017;
+      return new mongodb.Server(host, port);
+    });
+   return  new mongodb.ReplSetServers(replServers);
+}
+
 function getConnection(opts, cb) {
-	opts = getDbOpts(opts);
+    opts = getDbOpts(opts);
+    var mongodb = require('mongodb');
+    var svr = null;
+  //if replicaSet option is set then use a replicaSet connection
+  if (opts.replicaSet) {
+    svr = getReplicaSetServers(opts, mongodb);
+  } else {
+    //simple connection
+    svr = new mongodb.Server(opts.host, opts.port, {});
+  }
 
-	var mongodb = require('mongodb'),
-	server = new mongodb.Server(opts.host, opts.port, {});
-
-	new mongodb.Db(opts.db, server, {safe: true}).open(function (err, db) {
+  new mongodb.Db(opts.db, svr, {safe: true}).open(function (err, db) {
 		if (err) {
 			return cb(err);
 		}


### PR DESCRIPTION
I've added support for replica sets. To connect to a replica set, add this property to the config file:
```
"replicaSet" : ["localhost:27017","localhost:27018","localhost:27019"],
```