### PR TITLE
Use db.collection instead of mongodb.Collection

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -44,7 +44,7 @@ function getConnection(opts, cb) {
         return cb(authErr);
       }
 
-      var collection = new mongodb.Collection(db, 'migrations');
+      var collection = db.collection('migrations');
       cb(null, {
         connection: db,
         migrationCollection: collection


### PR DESCRIPTION
This change is necessary to use `mongo-migrate` with the 2.x MongoDB Node.js driver.