### PR TITLE
Allow optional Mongo authentication options in config file

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -52,7 +52,7 @@ function getConnection(opts, cb) {
     };
 
     if(opts.username) {
-      db.authenticate(opts.username,opts.password, {}, complete);
+      db.authenticate(opts.username, opts.password, opts.authOptions || {}, complete);
     } else {
       complete(null, null);
     }


### PR DESCRIPTION
Allows for advanced authentication options by adding an optional authOptions field to the configuration file. 