### PR TITLE
Better support for npm scripts

### DIFF
--- a/bin/mongo-migrate.js
+++ b/bin/mongo-migrate.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../index.js');

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "main": "index",
   "engines": {
     "node": ">= 0.8.x"
+  },
+  "bin": {
+    "mongo-migrate": "./bin/mongo-migrate.js"
   }
 }


### PR DESCRIPTION
Added bin field for better usage in package.json scripts corresponding to doc:
https://docs.npmjs.com/files/package.json#bin

example package.json:
```json
...
"scripts" : {
  "migrate:up": "mongo-migrate -runmm up",
  "migrate:down": "mongo-migrate -runmm down"
}
...
```

Migrations work with: `npm run migrate:up` or `npm run migrate:down`