### PR TITLE
Allow server settings from config

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -31,7 +31,7 @@ function getConnection(opts, cb) {
     svr = getReplicaSetServers(opts, mongodb);
   } else {
     //simple connection
-    svr = new mongodb.Server(opts.host, opts.port, {});
+    svr = new mongodb.Server(opts.host, opts.port, opts.server || {});
   }
 
   new mongodb.Db(opts.db, svr, {safe: true}).open(function (err, db) {


### PR DESCRIPTION
This way one can set something like:

```
var fs = require('fs');

var serverOptions = {};

if (process.env.MONGO_SSL_CERT) {
  serverOptions.ssl = true;
  serverOptions.sslCert = fs.readFileSync(process.env.MONGO_SSL_CERT);
  serverOptions.sslKey = fs.readFileSync(process.env.MONGO_SSL_CERT);
  serverOptions.sslCA = fs.readFileSync(process.env.MONGO_SSL_CA);
  if (process.env.MONGO_SSL_PASS) {
    serverOptions.sslPass = process.env.MONGO_SSL_PASS;
  }
  serverOptions.sslValidate = false;
}

module.exports = {
  "development": {
    "host": "localhost",
    "db": "app_development",
    "server": serverOptions
  },
  "production": {
    "host": process.env.MONGO_HOST || 'localhost',
    "db": process.env.MONGO_DB || 'app',
    "port": process.env.MONGO_PORT || 27017,
    "username": process.env.MONGO_USER || null,
    "password": process.env.MONGO_PASS || null,
    "server": serverOptions
  }
};

```

For the default-config, and SSL works!