### PR TITLE
Add new `-i` options, could prompt user before run migartions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Options:
 												//port: '27017' //include a port if necessary
 											}
 										}
+	-i								Prompt before run migrations
 
 Commands:
 	down [revision]		migrate down (stop at optional revision name/number)
@@ -211,5 +212,3 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-migrate",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Migration framework for mongo in node",
   "keywords": [
     "mongo",


### PR DESCRIPTION
Sometimes we don't want to run migrations immediately. It's meaningful check migrations before actually run them. So I add the new `-i` option, for example:

```bash
$ node ./node_modules/mongodb-migrate -runmm -i down
  down : migrations/0010-add-index.js
  down : migrations/0005-add-some-collection.js
These migrations will be run, continue? [y/N]
```