### PR TITLE
using parseint when setting port for replicaset to avoid error

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -16,7 +16,7 @@ function getReplicaSetServers(opts, mongodb) {
 	var replServers = opts.replicaSet.map(function(replicaSet) {
 		var split = replicaSet.split(":");
 		var host = split[0] || 'localhost';
-		var port = split[1] || 27017;
+		var port = parseInt(split[1]) || 27017;
 		return new mongodb.Server(host, port);
 	});
 	return new mongodb.ReplSet(replServers);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-migrate",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Migration framework for mongo in node",
   "keywords": [
     "mongo",


### PR DESCRIPTION
If port comes in as a string mongodb-core is throwing an error.  Using parseInt to avoid.

node_modules/mongodb-core/lib/topologies/replset.js:118
      throw new MongoError("seedlist entry must contain a host and port");
      ^
MongoError: seedlist entry must contain a host and port
    at node_modules/mongodb-core/lib/topologies/replset.js:118:13
    at Array.forEach (native)
    at new ReplSet (node_modules/mongodb-core/lib/topologies/replset.js:115:12)
    at new ReplSet (node_modules/mongodb/lib/replset.js:176:17)
    at getReplicaSetServers (node_modules/mongodb-migrate/lib/db.js:22:9)
    at Object.getConnection (node_modules/mongodb-migrate/lib/db.js:59:9)
    at performMigration (node_modules/mongodb-migrate/index.js:268:6)
    at commands.down (node_modules/mongodb-migrate/index.js:211:4)
    at runMongoMigrate (node_modules/mongodb-migrate/index.js:320:10)
    at Object.<anonymous> (node_modules/mongodb-migrate/index.js:380:2)