### PR TITLE
Added migration collection name override support in configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,23 @@ This would tell mongodb-migrate your config file looks something like:
 		}
 	}
 ```
+
+You can also use `migrationCollection` property to specify custom migration collection name, `"migrations"` will be 
+used by default.
+
+```
+	{
+		"dbSettings": {
+			"host": "localhost",
+			"db": "myDatabaseName",
+			//"port": 27017 //Specifying a port is optional
+			//"migrationCollection": "my-migrations" //Specifying migration collection name
+		}
+	}
+```
+
+
+
 To connect to a replica set, use  the `replicaSet` property:
 ```
 	{

--- a/lib/db.js
+++ b/lib/db.js
@@ -9,6 +9,7 @@ function getDbOpts(opts) {
 		port: 27017
 	};
 	opts.port = opts.port || 27017;
+    opts.migrationCollection || 'migrations';
 	return opts;
 }
 
@@ -22,13 +23,13 @@ function getReplicaSetServers(opts, mongodb) {
 	return new mongodb.ReplSet(replServers);
 }
 
-function getMigrationsCollection(db, mongodb) {
+function getMigrationsCollection(db, mongodb, opts) {
 	// for mongodb 2.x
 	if (typeof db.collection !== 'undefined') {
-		return db.collection('migrations');
+		return db.collection(opts.migrationCollection);
 	}
 
-	return new mongodb.Collection(db, 'migrations');
+	return new mongodb.Collection(db, opts.migrationCollection);
 }
 
 function getConnection(opts, cb) {
@@ -74,7 +75,7 @@ function getConnection(opts, cb) {
 
 			cb(null, {
 				connection: db,
-				migrationCollection: getMigrationsCollection(db, mongodb)
+				migrationCollection: getMigrationsCollection(db, mongodb, opts)
 			});
 		};
 


### PR DESCRIPTION
Hi,

I've added option to override migration collection name by property defined in configuration file. It may be useful when you have 2+ subsets(eg, schemas) of object you would like to migrate(update) in same database.